### PR TITLE
Refactor bot into cogs and add help command

### DIFF
--- a/koko2/bot.py
+++ b/koko2/bot.py
@@ -1,11 +1,7 @@
-# This example requires the 'members' privileged intent to use the Member converter
-# and the 'message_content' privileged intent for prefixed commands.
-
-import random
 import os
-
 import discord
 from discord.ext import commands
+
 
 description = """
 An example bot to showcase the discord.ext.commands extension module.
@@ -29,65 +25,10 @@ async def on_ready():
     print("------")
 
 
-@bot.command()
-async def add(ctx: commands.Context, left: int, right: int):
-    """Adds two numbers together."""
-    await ctx.send(str(left + right))
+for filename in os.listdir("cogs"):
+    if filename.endswith(".py"):
+        bot.load_extension(f"cogs.{filename[:-3]}")
 
-
-@bot.command()
-async def roll(ctx: commands.Context, dice: str):
-    """Rolls a die in NdN format."""
-    try:
-        rolls, limit = map(int, dice.split("d"))
-    except ValueError:
-        await ctx.send("Format has to be in NdN!")
-        return
-
-    # _ is used in the generation of our result as we don't need the number that comes from the usage of range(rolls).
-    result = ", ".join(str(random.randint(1, limit)) for _ in range(rolls))
-    await ctx.send(result)
-
-
-@bot.command(description="For when you wanna settle the score some other way")
-async def choose(ctx: commands.Context, *choices: str):
-    """Chooses between multiple choices."""
-    await ctx.send(random.choice(choices))
-
-
-@bot.command()
-async def repeat(ctx: commands.Context, times: int, *, content: str = "repeating..."):
-    """Repeats a message multiple times."""
-    for _ in range(times):
-        await ctx.send(content)
-
-
-@bot.command()
-async def joined(ctx: commands.Context, member: discord.Member):
-    """Says when a member joined."""
-    await ctx.send(f"{member.name} joined in {member.joined_at}")
-
-
-@bot.group()
-async def cool(ctx: commands.Context):
-    """
-    Says if a user is cool.
-
-    In reality this just checks if a subcommand is being invoked.
-    """
-
-    if ctx.invoked_subcommand is None:
-        await ctx.send(f"No, {ctx.subcommand_passed} is not cool")
-
-
-@cool.command(name="bot")
-async def _bot(ctx: commands.Context):
-    """Is the bot cool?"""
-    await ctx.send("Yes, the bot is cool.")
-
-for filename in os.listdir(r"cogs"):
-        if filename.endswith('.py'):
-                bot.load_extension(f'cogs.{filename[:-3]}')
 
 token = os.getenv("DISCORD_TOKEN")
 bot.run(token)

--- a/koko2/cogs/general.py
+++ b/koko2/cogs/general.py
@@ -1,0 +1,63 @@
+import random
+import discord
+from discord.ext import commands
+
+
+class General(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command()
+    async def add(self, ctx: commands.Context, left: int, right: int):
+        """Adds two numbers together."""
+        await ctx.send(str(left + right))
+
+    @commands.command()
+    async def roll(self, ctx: commands.Context, dice: str):
+        """Rolls a die in NdN format."""
+        try:
+            rolls, limit = map(int, dice.split("d"))
+        except ValueError:
+            await ctx.send("Format has to be in NdN!")
+            return
+        result = ", ".join(str(random.randint(1, limit)) for _ in range(rolls))
+        await ctx.send(result)
+
+    @commands.command(
+        description="For when you wanna settle the score some other way"
+    )
+    async def choose(self, ctx: commands.Context, *choices: str):
+        """Chooses between multiple choices."""
+        await ctx.send(random.choice(choices))
+
+    @commands.command()
+    async def repeat(
+        self,
+        ctx: commands.Context,
+        times: int,
+        *,
+        content: str = "repeating...",
+    ):
+        """Repeats a message multiple times."""
+        for _ in range(times):
+            await ctx.send(content)
+
+    @commands.command()
+    async def joined(self, ctx: commands.Context, member: discord.Member):
+        """Says when a member joined."""
+        await ctx.send(f"{member.name} joined in {member.joined_at}")
+
+    @commands.group()
+    async def cool(self, ctx: commands.Context):
+        """Says if a user is cool."""
+        if ctx.invoked_subcommand is None:
+            await ctx.send(f"No, {ctx.subcommand_passed} is not cool")
+
+    @cool.command(name="bot")
+    async def _bot(self, ctx: commands.Context):
+        """Is the bot cool?"""
+        await ctx.send("Yes, the bot is cool.")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(General(bot))

--- a/koko2/cogs/hello.py
+++ b/koko2/cogs/hello.py
@@ -1,16 +1,22 @@
+import discord
+from discord.ext import commands
+
+
 class Hello(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._last_member = None
 
     @commands.Cog.listener()
-    async def on_member_join(self, member):
+    async def on_member_join(self, member: discord.Member):
         channel = member.guild.system_channel
         if channel is not None:
             await channel.send(f'Welcome {member.mention}.')
 
     @commands.command()
-    async def hello(self, ctx, *, member: discord.Member = None):
+    async def hello(
+        self, ctx: commands.Context, *, member: discord.Member = None
+    ):
         """Says hello"""
         member = member or ctx.author
         if self._last_member is None or self._last_member.id != member.id:
@@ -19,4 +25,6 @@ class Hello(commands.Cog):
             await ctx.send(f'Hello {member.name}... This feels familiar.')
         self._last_member = member
 
-bot.add_cog(Hello(bot))
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Hello(bot))

--- a/koko2/cogs/help.py
+++ b/koko2/cogs/help.py
@@ -1,0 +1,27 @@
+import discord
+from discord.ext import commands
+
+
+class Help(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.slash_command(name="help", description="Show this message")
+    async def help(self, ctx: discord.ApplicationContext):
+        embed = discord.Embed(
+            title="Bot Commands",
+            description="Here is a list of available commands",
+            color=discord.Color.blurple(),
+        )
+        for command in self.bot.walk_commands():
+            if command.parent is None:
+                embed.add_field(
+                    name=command.qualified_name,
+                    value=command.help or "No description provided.",
+                    inline=False,
+                )
+        await ctx.respond(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Help(bot))


### PR DESCRIPTION
## Summary
- organize commands under new cogs
- provide an embedded `/help` slash command
- streamline `bot.py` to just load cogs

## Testing
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686313cd91e4832f93b13801dc7c1b36